### PR TITLE
Allow multiple Backbone routers

### DIFF
--- a/editorsnotes/templates/base.html
+++ b/editorsnotes/templates/base.html
@@ -31,15 +31,7 @@
         {% endif %}
       </script>
 
-    {% compress js %}
-      {% include "base_js_bundle.html" %}
-    {% endcompress %}
-
-    {% if request.user.is_authenticated %}
-    {% compress js %}
-    {% include "admin_js_bundle.html" %}
-    {% endcompress %}
-    {% endif %}
+    {% include "browserify_bundles.html" %}
 
     <script type="text/javascript" src="https://login.persona.org/include.js"></script>
     <script type="text/javascript" src="{% static "function/lib/browserid.js" %}"></script>

--- a/editorsnotes_app/src/index-admin.js
+++ b/editorsnotes_app/src/index-admin.js
@@ -10,7 +10,6 @@ $(document).ready(function () {
   initEditors();
 
   window.EditorsNotes.admin = new AdminRouter();
-  Backbone.history.start({ pushState: true });
 });
 
 AdminRouter = Backbone.Router.extend({

--- a/editorsnotes_app/src/index-base.js
+++ b/editorsnotes_app/src/index-base.js
@@ -1,13 +1,15 @@
 "use strict";
 
 var $ = require('./jquery')
-  , Backbone = require('./backbone')
+  , Backbone = window.Backbone = require('./backbone')
   , BaseRouter
 
 $(document).ready(function () {
   initTimeago();
   initTooltips();
   initAutocomplete();
+
+  window.EditorsNotes.base = new BaseRouter();
 });
 
 BaseRouter = Backbone.Router.extend({

--- a/editorsnotes_app/templates/browserify_bundles.html
+++ b/editorsnotes_app/templates/browserify_bundles.html
@@ -1,0 +1,16 @@
+{% load compress %}
+
+{% compress js %}
+  {% include "base_js_bundle.html" %}
+{% endcompress %}
+
+{% if request.user.is_authenticated %}
+  {% compress js %}
+    {% include "admin_js_bundle.html" %}
+  {% endcompress %}
+{% endif %}
+
+<script type="text/javascript">
+$(document).ready(function () { Backbone.history.start({ pushState: true }) });
+</script>
+


### PR DESCRIPTION
Before, only one was being instantiated before calling
Backbone.history.start()