### PR TITLE
Suffix routing

### DIFF
--- a/editorsnotes/api/renderers.py
+++ b/editorsnotes/api/renderers.py
@@ -7,9 +7,18 @@ from rdflib import Graph
 from .ld import CONTEXT
 
 
-class BrowsableJSONAPIRenderer(renderers.BrowsableAPIRenderer):
+class BrowsableJSONLDRenderer(renderers.BrowsableAPIRenderer):
+    format = 'jsonld-browse'
+
     def get_default_renderer(self, view):
         return JSONLDRenderer()
+
+
+class BrowsableTurtleRenderer(renderers.BrowsableAPIRenderer):
+    format = 'ttl-browse'
+
+    def get_default_renderer(self, view):
+        return TurtleRenderer()
 
 
 class JSONLDRenderer(renderers.JSONRenderer):

--- a/editorsnotes/api/renderers.py
+++ b/editorsnotes/api/renderers.py
@@ -13,6 +13,9 @@ class BrowsableJSONAPIRenderer(renderers.BrowsableAPIRenderer):
 
 
 class JSONLDRenderer(renderers.JSONRenderer):
+    media_type = 'application/ld+json'
+    format = 'jsonld'
+
     def render(self, data, accepted_media_type=None, renderer_context=None):
         data_with_context = OrderedDict()
 

--- a/editorsnotes/api/urls.py
+++ b/editorsnotes/api/urls.py
@@ -7,7 +7,7 @@ import views
 
 def format_patterns(urlpatterns):
     "If a URL pattern ends in a slash, it should be able to be rendered as different types"
-    suffixes = ['json', 'jsonld', 'ttl', 'api']
+    suffixes = ['json', 'jsonld', 'jsonld-browse', 'ttl', 'ttl-browse']
     ret = []
     for urlpattern in urlpatterns:
         if isinstance(urlpattern, RegexURLPattern):

--- a/editorsnotes/api/urls.py
+++ b/editorsnotes/api/urls.py
@@ -7,7 +7,7 @@ import views
 
 def format_patterns(urlpatterns):
     "If a URL pattern ends in a slash, it should be able to be rendered as different types"
-    suffixes = ['json', 'api']
+    suffixes = ['json', 'jsonld', 'ttl', 'api']
     ret = []
     for urlpattern in urlpatterns:
         if isinstance(urlpattern, RegexURLPattern):

--- a/editorsnotes/settings.py
+++ b/editorsnotes/settings.py
@@ -134,8 +134,9 @@ REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
         'editorsnotes.api.renderers.JSONLDRenderer',
+        'editorsnotes.api.renderers.BrowsableJSONLDRenderer',
         'editorsnotes.api.renderers.TurtleRenderer',
-        'editorsnotes.api.renderers.BrowsableJSONAPIRenderer',
+        'editorsnotes.api.renderers.BrowsableTurtleRenderer',
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 25

--- a/editorsnotes/settings.py
+++ b/editorsnotes/settings.py
@@ -133,8 +133,9 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
-        'editorsnotes.api.renderers.BrowsableJSONAPIRenderer',
+        'editorsnotes.api.renderers.JSONLDRenderer',
         'editorsnotes.api.renderers.TurtleRenderer',
+        'editorsnotes.api.renderers.BrowsableJSONAPIRenderer',
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 25


### PR DESCRIPTION
This enables the suffixes `.jsonld`, `.jsonld-browse`, `.ttl`, and `.ttl-browse` to be appended to URLs to get specific content types. The `-browse` variations are rendered using the Django REST Framework browsable renderer.